### PR TITLE
Correção de bug das notas cuja soma davam '8'

### DIFF
--- a/Calcular_Notas_UNAMA/src/calcular_notas_unama/Notas_UNAMA.java
+++ b/Calcular_Notas_UNAMA/src/calcular_notas_unama/Notas_UNAMA.java
@@ -160,7 +160,7 @@ public class Notas_UNAMA extends javax.swing.JFrame {
                     
                     jresultado.setText("Você passou!!");
                     
-                }else if(calculo < Media_Para_Passar && calculo > 4){
+                }else if(calculo < Media_Para_Passar && calculo >= 4){
                     
                     jresultado.setText("<html>" +"Você foi para prova final!! " 
                             + "</br>" +"Precisa tirar " + prova_final + " para passar ");


### PR DESCRIPTION
A variável "calculo", quando as notas somam 8, é igual a 4.
No código eram testados o caso em que essa variável era testada nos casos em que ela era maior ou menor que 4, mas nunca no caso em que a variável era igual.
Eu adicionei a verificação para o caso em que esse valor era igual e coloquei como prova final.